### PR TITLE
fix a nasty python3 error

### DIFF
--- a/deeptools/correlation.py
+++ b/deeptools/correlation.py
@@ -83,7 +83,7 @@ class Correlation:
 
             self.matrix = np.ma.compress_rows(np.ma.masked_invalid(self.matrix))
 
-        self.labels = _ma['labels']
+        self.labels = self.labels = list(map(str, _ma['labels']))
 
         assert len(self.labels) == self.matrix.shape[1], "ERROR, length of labels is not equal " \
                                                          "to length of matrix samples"


### PR DESCRIPTION
The following command:
```
plotCorrelation --corData test-data/multiBamSummary_result1.npz --plotFile foo.png --corMethod "spearman" --whatToPlot "heatmap"  --colorMap 'RdYlBu'  --plotTitle ''  --plotWidth 11.0 --plotHeight 9.5  --plotFileFormat "png"  --outFileCorMatrix foo2.ma
```
produces the following error in a python3 environment:
```
[b'bowtie2 test1.bam', b'bowtie2 test1.bam']
Traceback (most recent call last):
  File "/home/bag/miniconda3/envs/__deeptools@2.5.5/bin/plotCorrelation", line 11, in <module>
    main(args)
  File "/home/bag/miniconda3/envs/__deeptools@2.5.5/lib/python3.6/site-packages/deeptools/plotCorrelation.py", line 224, in main
    corr.save_corr_matrix(args.outFileCorMatrix)
  File "/home/bag/miniconda3/envs/__deeptools@2.5.5/lib/python3.6/site-packages/deeptools/correlation.py", line 170, in save_corr_matrix
    file_handle.write("\t'" + "'\t'".join(self.labels) + "'\n")
TypeError: sequence item 0: expected str instance, numpy.bytes_ found
```
I think this is due to an older version of a `/multiBamSummary` matrix that once loaded with py3 produces this error. I think its worth to have this fix in to also load old datasets. we could break this in deepTools3 is really needed.