### PR TITLE
Feature/fix734

### DIFF
--- a/deeptools/correlation.py
+++ b/deeptools/correlation.py
@@ -646,7 +646,9 @@ class Correlation:
             Wt = np.dot(m2, Vh.T).T
 
         if plot_filename is not None:
-            n = len(self.labels)
+            n = n_bars = len(self.labels)
+            if eigenvalues.size < n:
+                n_bars = eigenvalues.size
             markers = itertools.cycle(matplotlib.markers.MarkerStyle.filled_markers)
             if cols is not None:
                 colors = itertools.cycle(cols)
@@ -676,13 +678,13 @@ class Correlation:
                                  prop={'size': 12}, markerscale=0.9)
 
                 # Scree plot
-                ind = np.arange(n)  # the x locations for the groups
+                ind = np.arange(n_bars)  # the x locations for the groups
                 width = 0.35        # the width of the bars
 
                 if mpl.__version__ >= "2.0.0":
-                    ax2.bar(2 * width + ind, eigenvalues[:n], width * 2)
+                    ax2.bar(2 * width + ind, eigenvalues[:n_bars], width * 2)
                 else:
-                    ax2.bar(width + ind, eigenvalues[:n], width * 2)
+                    ax2.bar(width + ind, eigenvalues[:n_bars], width * 2)
                 ax2.set_ylabel('Eigenvalue')
                 ax2.set_xlabel('Principal Component')
                 ax2.set_title('Scree plot')


### PR DESCRIPTION
The problem with the solution proposed at e4028c1c77bc3496fef57d2360a714e2d460b210 is that then the number of samples on the main plot corresponds is set to be the number of eigenvalues and thus some sample are missing from the plot. I tried to solve this by creating two separate variables `n_bar` and `n` that are set to the same value and only `n_bar` is modified when the condition `if eigenvalues.size < n:` is met. 
