### PR TITLE
Add 'se' and 'std' to possible heatmap summary plot types

### DIFF
--- a/deeptools/heatmapper_utilities.py
+++ b/deeptools/heatmapper_utilities.py
@@ -9,7 +9,7 @@ import plotly.graph_objs as go
 old_settings = np.seterr(all='ignore')
 
 
-def plot_single(ax, ma, average_type, color, label, plot_type='simple'):
+def plot_single(ax, ma, average_type, color, label, plot_type='lines'):
     """
     Adds a line to the plot in the given ax using the specified method
 
@@ -30,8 +30,8 @@ def plot_single(ax, ma, average_type, color, label, plot_type='simple'):
     plot_type: str
         type of plot. Either 'se' for standard error, 'std' for
         standard deviation, 'overlapped_lines' to plot each line of the matrix,
-        fill to plot the area between the x axis and the value or None, just to
-        plot the average line.
+        fill to plot the area between the x axis and the value or any other string to
+        just plot the average line.
 
     Returns
     -------
@@ -69,7 +69,6 @@ def plot_single(ax, ma, average_type, color, label, plot_type='simple'):
         color = pltcolors.to_hex(color, keep_alpha=True)
     ax.plot(x, summary, color=color, label=label, alpha=0.9)
     if plot_type == 'fill':
-        pass
         ax.fill_between(x, summary, facecolor=color, alpha=0.6, edgecolor='none')
 
     if plot_type in ['se', 'std']:
@@ -91,7 +90,7 @@ def plot_single(ax, ma, average_type, color, label, plot_type='simple'):
     return ax
 
 
-def plotly_single(ma, average_type, color, label, plot_type='simple'):
+def plotly_single(ma, average_type, color, label, plot_type='line'):
     """A plotly version of plot_single. Returns a list of traces"""
     summary = list(np.ma.__getattribute__(average_type)(ma, axis=0))
     x = list(np.arange(len(summary)))

--- a/deeptools/parserCommon.py
+++ b/deeptools/parserCommon.py
@@ -563,6 +563,17 @@ def heatmapperOptionalArgs(mode=['heatmap', 'profile'][0]):
                               default=8)
 
     elif mode == 'heatmap':
+        optional.add_argument(
+            '--plotType',
+            help='"lines" will plot the profile line based '
+            'on the average type selected. "fill" '
+            'fills the region between zero and the profile '
+            'curve. The fill in color is semi transparent to '
+            'distinguish different profiles. "se" and "std" '
+            'color the region between the profile and the '
+            'standard error or standard deviation of the data.',
+            choices=['lines', 'fill', 'se', 'std'],
+            default='lines')
         optional.add_argument('--sortRegions',
                               help='Whether the heatmap should present '
                               'the regions sorted. The default is '

--- a/deeptools/plotHeatmap.py
+++ b/deeptools/plotHeatmap.py
@@ -115,7 +115,7 @@ def prepare_layout(hm_matrix, heatmapsize, showSummaryPlot, showColorbar, perGro
     return grids
 
 
-def addProfilePlot(hm, plt, fig, grids, iterNum, iterNum2, perGroup, averageType, yAxisLabel, color_list, yMin, yMax, wspace, hspace, colorbar_position, label_rotation=0.0):
+def addProfilePlot(hm, plt, fig, grids, iterNum, iterNum2, perGroup, averageType, plot_type, yAxisLabel, color_list, yMin, yMax, wspace, hspace, colorbar_position, label_rotation=0.0):
     """
     A function to add profile plots to the given figure, possibly in a custom grid subplot which mimics a tight layout (if wspace and hspace are not None)
     """
@@ -153,7 +153,7 @@ def addProfilePlot(hm, plt, fig, grids, iterNum, iterNum2, perGroup, averageType
                         averageType,
                         color_list[group],
                         line_label,
-                        plot_type='simple')
+                        plot_type=plot_type)
 
         if sample_id > 0 and len(yMin) == 1 and len(yMax) == 1:
             plt.setp(ax_profile.get_yticklabels(), visible=False)
@@ -381,6 +381,7 @@ def plotMatrix(hm, outFileName,
                heatmapHeight=25,
                heatmapWidth=7.5,
                perGroup=False, whatToShow='plot, heatmap and colorbar',
+               plot_type='lines',
                image_format=None,
                legend_location='upper-left',
                box_around_heatmaps=True,
@@ -543,7 +544,7 @@ def plotMatrix(hm, outFileName,
         else:
             iterNum = hm.matrix.get_num_samples()
             iterNum2 = numgroups
-        ax_list = addProfilePlot(hm, plt, fig, grids, iterNum, iterNum2, perGroup, averageType, yAxisLabel, color_list, yMin, yMax, None, None, colorbar_position, label_rotation)
+        ax_list = addProfilePlot(hm, plt, fig, grids, iterNum, iterNum2, perGroup, averageType, plot_type, yAxisLabel, color_list, yMin, yMax, None, None, colorbar_position, label_rotation)
         if len(yMin) > 1 or len(yMax) > 1:
             # replot with a tight layout
             import matplotlib.tight_layout as tl
@@ -554,7 +555,7 @@ def plotMatrix(hm, outFileName,
             for ax in ax_list:
                 fig.delaxes(ax)
 
-            ax_list = addProfilePlot(hm, plt, fig, grids, iterNum, iterNum2, perGroup, averageType, yAxisLabel, color_list, yMin, yMax, kwargs['wspace'], kwargs['hspace'], colorbar_position, label_rotation)
+            ax_list = addProfilePlot(hm, plt, fig, grids, iterNum, iterNum2, perGroup, averageType, plot_type, yAxisLabel, color_list, yMin, yMax, kwargs['wspace'], kwargs['hspace'], colorbar_position, label_rotation)
 
         if legend_location != 'none':
             ax_list[-1].legend(loc=legend_location.replace('-', ' '), ncol=1, prop=fontP,
@@ -832,6 +833,7 @@ def main(args=None):
                args.heatmapWidth,
                args.perGroup,
                args.whatToShow,
+               plot_type=args.plotType,
                image_format=args.plotFileFormat,
                legend_location=args.legendLocation,
                box_around_heatmaps=args.boxAroundHeatmaps,

--- a/deeptools/plotProfile.py
+++ b/deeptools/plotProfile.py
@@ -94,7 +94,7 @@ class Profile(object):
                  plot_height=7,
                  plot_width=11,
                  per_group=False,
-                 plot_type='simple',
+                 plot_type='lines',
                  image_format=None,
                  color_list=None,
                  legend_location='auto',

--- a/galaxy/wrapper/plotHeatmap.xml
+++ b/galaxy/wrapper/plotHeatmap.xml
@@ -42,6 +42,8 @@
                     --averageTypeSummaryPlot '$advancedOpt.averageTypeSummaryPlot'
                 #end if
 
+                --plotType '$advancedOpt.plotType'
+
                 #if str($advancedOpt.missingDataColor.value) != "None":
                     --missingDataColor '$advancedOpt.missingDataColor'
                 #end if
@@ -138,7 +140,12 @@
                     <option value="sum">sum</option>
                     <option value="std">std</option>
                 </param>
-
+                <param argument="--plotType" type="select" label="Type of summary plot">
+                    <option value="lines">plot the profile line based on the statistic selected above.</option>
+                    <option value="fill">fills the region between zero and the profile.</option>
+                    <option value="se">color the region between the profile and the standard error.</option>
+                    <option value="std">color the region between the profile and the standard deviation.</option>
+                </param>
                 <param argument="--missingDataColor" type="text" value="black" optional="true" label="Missing data color"
                     help="If 'Represent missing data as zero' is not set, such cases will be colored in black by default.
                     By using this parameter a different color can be set. A value between 0 and 1 will be used for a gray scale (black is 0).


### PR DESCRIPTION
I think `se` is quite useful when dealing with heatmaps for tracks with few (< 200) regions of interest.

<img width="185" alt="screen shot 2019-01-09 at 21 32 40" src="https://user-images.githubusercontent.com/6804901/50926794-29a60580-1456-11e9-8088-4cbd32cad3c5.png">


**Welcome to deepTools GitHub repository! Please check the following regarding
your pull request :**

 - [x] Does the PR contain new feature?
 - [ ] Does the PR contain bugfix?
 - [ ] Does the PR contain documentation changes?
 - s ] Does the PR contain changes to the galaxy wrapper?
