### PR TITLE
Add Arabidopsis TAIR10 (A_thaliana_Jun_2009)

### DIFF
--- a/docs/content/feature/effectiveGenomeSize.rst
+++ b/docs/content/feature/effectiveGenomeSize.rst
@@ -19,6 +19,7 @@ dm3      162367812
 dm6      142573017
 GRCz10   1369631918
 WBcel235 100286401
+TAIR10   119481543 
 ======== ==============
 
 These values only appropriate if multimapping reads are included. If they are excluded (or there's any MAPQ filter applied), then values derived from option 2 are more appropriate. These are then based on the read length. We can approximate these values for various read lengths using the `khmer program <http://khmer.readthedocs.io/en/v2.1.1/>`__ program and ``unique-kmers.py`` in particular. A table of effective genome sizes given a read length using this method is provided below:


### PR DESCRIPTION
Using output from:
faCount A_thaliana_Jun_2009.fa 
#seq	len	A	C	G	T	N	cpg
Chr1	30427671	9709674	5435374	5421151	9697113	164359	697370
Chr2	19698289	6315641	3542973	3520766	6316348	2561	457572
Chr3	23459830	7484757	4258333	4262704	7448059	5977	559031
Chr4	18585056	5940546	3371349	3356091	5914038	3032	439585
Chr5	26975502	8621974	4832253	4858759	8652238	10278	630299
ChrC	154478	48546	28496	27570	49866	0	4639
ChrM	366924	102464	82661	81609	100190	0	13697
total	119667750	38223602	21551439	21528650	38177852	186207	2802193
hpc $ python
Python 2.7.11 (default, Jul 25 2019, 12:10:26) 
[GCC 4.8.5 20150623 (Red Hat 4.8.5-28)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> 119667750-186207
119481543


**Welcome to deepTools GitHub repository! Please check the following regarding
your pull request :**

 - [ ] Does the PR contain new feature?
 - [ ] Does the PR contain bugfix?
 - [x] Does the PR contain documentation changes?
 - [ ] Does the PR contain changes to the galaxy wrapper?
