### PR TITLE
Using --xRange and --yRange fails in galaxy due to the single quote. …

### DIFF
--- a/galaxy/wrapper/plotCorrelation.xml
+++ b/galaxy/wrapper/plotCorrelation.xml
@@ -19,10 +19,10 @@
             #else:
                 --plotTitle '$plotting_type.plotTitle'
                 #if str($plotting_type.xRange) != '':
-                    --xRange '$plotting_type.xRange'
+                    --xRange $plotting_type.xRange
                 #end if
                 #if str($plotting_type.yRange) != '':
-                    --yRange '$plotting_type.yRange'
+                    --yRange $plotting_type.yRange
                 #end if
                 $plotting_type.log1p
             #end if


### PR DESCRIPTION
Single quotes removed. 


**Welcome to deepTools GitHub repository! Please check the following regarding
your pull request :**

 - [ ] Does the PR contain new feature? 
no
 - [ ] Does the PR contain bugfix?
yes
 - [ ] Does the PR contain documentation changes?
no
 - [ ] Does the PR contain changes to the galaxy wrapper?
yes
