### PR TITLE
Update correlation.py

### DIFF
--- a/deeptools/correlation.py
+++ b/deeptools/correlation.py
@@ -433,7 +433,6 @@ class Correlation:
         """
 
         num_samples = self.matrix.shape[1]
-        corr_matrix = self.compute_correlation()
         grids = gridspec.GridSpec(num_samples, num_samples)
         grids.update(wspace=0, hspace=0)
         fig = plt.figure(figsize=(2 * num_samples, 2 * num_samples))
@@ -441,6 +440,7 @@ class Correlation:
         plt.suptitle(plot_title)
         if log1p is True:
             self.matrix = np.log1p(self.matrix)
+        corr_matrix = self.compute_correlation()
         min_xvalue = self.matrix.min()
         max_xvalue = self.matrix.max()
         min_yvalue = min_xvalue


### PR DESCRIPTION
Previously, when people use plotCorrelation.py to generate correlation scatter plot with `--log1p`, the scatter plot is under log1p transformed, but the correlation coefficient is not, which will be misleading. In this PR, I adjusted the order of calculating cor coef, so now the behavior will be consistent.

**Welcome to deepTools GitHub repository! Please check the following regarding
your pull request :**

 - [ ] Does the PR contain new feature?
 - [ * ] Does the PR contain bugfix?
 - [ ] Does the PR contain documentation changes?
 - [ ] Does the PR contain changes to the galaxy wrapper?
