### PR TITLE
 Adding independent ranges by sample option: for zMax zMin yMin and y…

### DIFF
--- a/deeptools/heatmapper.py
+++ b/deeptools/heatmapper.py
@@ -1150,6 +1150,14 @@ class _matrix(object):
     def get_num_groups(self):
         return len(self.group_labels)
 
+    def get_percentile_by_samples(self,percentile):
+        percentile_per_samples = []
+        for sample in range(self.get_num_samples()):
+            sample_start = self.sample_boundaries[sample]
+            sample_end = self.sample_boundaries[sample + 1]
+            percentile_per_samples.append(np.percentile(np.ma.masked_invalid(self.matrix[:,sample_start:sample_end]),percentile))
+        return percentile_per_samples
+
     def set_group_labels(self, new_labels):
         """ sets new labels for groups
         """

--- a/deeptools/plotHeatmap.py
+++ b/deeptools/plotHeatmap.py
@@ -186,7 +186,11 @@ def addProfilePlot(hm, plt, fig, grids, iterNum, iterNum2, perGroup, averageType
     # It turns out that set_ylim only takes np.float64s
     for sample_id, subplot in enumerate(ax_list):
         localYMin = yMin[sample_id % len(yMin)]
+        if localYMin == "independent":
+            localYMin = ax_list[sample_id].get_ylim()[0]
         localYMax = yMax[sample_id % len(yMax)]
+        if localYMax == "independent":
+            localYMax = ax_list[sample_id].get_ylim()[1]
         lims = [globalYmin, globalYmax]
         if localYMin:
             if localYMax:
@@ -412,6 +416,8 @@ def plotMatrix(hm, outFileName,
             zMin = [None]
         else:
             zMin = [zMin]  # convert to list to support multiple entries
+    elif zMin == ["independent"]:
+        zMin = hm.matrix.get_percentile_by_samples(1.0)
     elif 'auto' in zMin:
         matrix_flatten = hm.matrix.flatten()
         auto_min = np.percentile(matrix_flatten, 1.0)
@@ -432,6 +438,8 @@ def plotMatrix(hm, outFileName,
             zMax = [None]
         else:
             zMax = [zMax]
+    elif zMax == ["independent"]:
+        zMax = hm.matrix.get_percentile_by_samples(98.0)
     elif 'auto' in zMax:
         matrix_flatten = hm.matrix.flatten()
         auto_max = np.percentile(matrix_flatten, 98.0)
@@ -452,8 +460,13 @@ def plotMatrix(hm, outFileName,
 
     if yMin is None:
         yMin = [None]
+    elif yMin == ["independent"]:
+        yMin = ["independent"] * hm.matrix.get_num_samples()
+
     if yMax is None:
         yMax = [None]
+    elif yMax == ["independent"]:
+        yMax = ["independent"] * hm.matrix.get_num_samples()
     if not isinstance(yMin, list):
         yMin = [yMin]
     if not isinstance(yMax, list):


### PR DESCRIPTION
…Max adding the possibility to set them to the value independent. It creates different ranges for each samples

**Welcome to deepTools GitHub repository! Please check the following regarding
your pull request :**

 - [x ] Does the PR contain new feature?
 - [ ] Does the PR contain bugfix?
 - [ ] Does the PR contain documentation changes?
 - [ ] Does the PR contain changes to the galaxy wrapper?

Hello, in one of the use case that I have for deeptools, the range of the different samples that I want to plot using plotHeatmap are very different and not related.
Here is what is generated with the following 'default' command without setting any explicit z-ranges or y-rangesranges:
```
plotHeatmap  -m ../repli1D/results/K562_1000_inverse/opti/plotHeatmapmulti_meta_both_marks_init_H3K36me3  -out ../repli1D/results/K562_1000_inverse/opti/multi_meta_both_marks_init_H3K36me3.png --samplesLabel Initiation H3K36me3 --colorMap hot_r hot_r  --whatToShow 'plot, heatmap and colorbar' --sortRegions ascend  --sortUsingSamples 1 --regionsLabel 'FPKM>1' 'FPKM<1'
```
![multi_meta_both_marks_init_H3K36me3](https://user-images.githubusercontent.com/29305032/150345331-5dcb6dd3-2e36-4eb7-880b-e7739c9b5120.png)

As the ranges are differents, the first sample is shrinked. I could set yMax yMin zMin zMax for each samples, however it would require a lot of adjustement.
I propose to add for all these parameters a  keyword independent, that set their values as if the samples would be independent.
running:
```
plotHeatmap --zMax independent --zMin independent --yMax independent --yMin independent -m ../repli1D/results/K562_1000_inverse/opti/plotHeatmapmulti_meta_both_marks_init_H3K36me3  -out ../repli1D/results/K562_1000_inverse/opti/multi_meta_both_marks_init_H3K36me3.png --samplesLabel Initiation H3K36me3 --colorMap hot_r hot_r  --whatToShow 'plot, heatmap and colorbar' --sortRegions ascend  --sortUsingSamples 1 --regionsLabel 'FPKM>1' 'FPKM<1'

```
now produce the desired behaviour:
![multi_meta_both_marks_init_H3K36me3](https://user-images.githubusercontent.com/29305032/150346150-6a30d89c-16f7-405a-b6c0-f1b72a958359.png)

