### PR TITLE
np.{type} to {type}

### DIFF
--- a/deeptools/heatmapper.py
+++ b/deeptools/heatmapper.py
@@ -777,7 +777,7 @@ class heatmapper(object):
             # split the line into bed interval and matrix values
             region = line.split('\t')
             chrom, start, end, name, score, strand = region[0:6]
-            matrix_row = np.ma.masked_invalid(np.fromiter(region[6:], np.float64))
+            matrix_row = np.ma.masked_invalid(np.fromiter(region[6:], float64))
             matrix_rows.append(matrix_row)
             starts = start.split(",")
             ends = end.split(",")
@@ -852,7 +852,7 @@ class heatmapper(object):
             # join np_array values
             # keeping nans while converting them to strings
             if not np.ma.is_masked(score_list[idx]):
-                np.float64(score_list[idx])
+                float64(score_list[idx])
             matrix_values = "\t".join(
                 np.char.mod('%f', self.matrix.matrix[idx, :]))
             starts = ["{0}".format(x[0]) for x in region[1]]
@@ -1345,7 +1345,7 @@ class _matrix(object):
         to_keep = []
         score_list = np.ma.masked_invalid(np.mean(self.matrix, axis=1))
         for idx, region in enumerate(self.regions):
-            if np.ma.is_masked(score_list[idx]) or np.float64(score_list[idx]) == 0:
+            if np.ma.is_masked(score_list[idx]) or float64(score_list[idx]) == 0:
                 continue
             else:
                 to_keep.append(idx)

--- a/deeptools/heatmapper.py
+++ b/deeptools/heatmapper.py
@@ -777,7 +777,7 @@ class heatmapper(object):
             # split the line into bed interval and matrix values
             region = line.split('\t')
             chrom, start, end, name, score, strand = region[0:6]
-            matrix_row = np.ma.masked_invalid(np.fromiter(region[6:], float64))
+            matrix_row = np.ma.masked_invalid(np.fromiter(region[6:], float))
             matrix_rows.append(matrix_row)
             starts = start.split(",")
             ends = end.split(",")
@@ -852,7 +852,7 @@ class heatmapper(object):
             # join np_array values
             # keeping nans while converting them to strings
             if not np.ma.is_masked(score_list[idx]):
-                float64(score_list[idx])
+                float(score_list[idx])
             matrix_values = "\t".join(
                 np.char.mod('%f', self.matrix.matrix[idx, :]))
             starts = ["{0}".format(x[0]) for x in region[1]]
@@ -1253,10 +1253,10 @@ class _matrix(object):
         matrix = np.asarray(self.matrix)
         matrix_to_cluster = matrix
         if clustering_samples is not None:
-            assert all(i > 0 for i in clustering_samples),\
+            assert all(i > 0 for i in clustering_samples), \
                 "all indices should be bigger than or equal to 1."
             assert all(i <= len(self.sample_labels) for i in
-                       clustering_samples),\
+                       clustering_samples), \
                 "each index should be smaller than or equal to {}(total "\
                 "number of samples.)".format(len(self.sample_labels))
 
@@ -1345,7 +1345,7 @@ class _matrix(object):
         to_keep = []
         score_list = np.ma.masked_invalid(np.mean(self.matrix, axis=1))
         for idx, region in enumerate(self.regions):
-            if np.ma.is_masked(score_list[idx]) or float64(score_list[idx]) == 0:
+            if np.ma.is_masked(score_list[idx]) or float(score_list[idx]) == 0:
                 continue
             else:
                 to_keep.append(idx)

--- a/deeptools/plotFingerprint.py
+++ b/deeptools/plotFingerprint.py
@@ -240,7 +240,7 @@ def getSyntheticJSD(vec):
     lamb = np.mean(vec)  # Average coverage
     coverage = np.sum(vec)
 
-    chip = np.zeros(MAXLEN, dtype=np.int)
+    chip = np.zeros(MAXLEN, dtype=int)
     for val in vec:
         # N.B., we need to clip past the end of the array
         if val >= MAXLEN:
@@ -277,8 +277,8 @@ def getJSD(args, idx, mat):
         return np.NAN
 
     # These will hold the coverage histograms
-    chip = np.zeros(MAXLEN, dtype=np.int)
-    input = np.zeros(MAXLEN, dtype=np.int)
+    chip = np.zeros(MAXLEN, dtype=int)
+    input = np.zeros(MAXLEN, dtype=int)
     for row in mat:
         # ChIP
         val = row[idx]

--- a/deeptools/plotHeatmap.py
+++ b/deeptools/plotHeatmap.py
@@ -180,21 +180,21 @@ def addProfilePlot(hm, plt, fig, grids, iterNum, iterNum2, perGroup, averageType
         ticks[0].label1.set_horizontalalignment('left')
         ticks[-1].label1.set_horizontalalignment('right')
 
-        globalYmin = min(np.float64(globalYmin), ax_profile.get_ylim()[0])
+        globalYmin = min(float64(globalYmin), ax_profile.get_ylim()[0])
         globalYmax = max(globalYmax, ax_profile.get_ylim()[1])
 
-    # It turns out that set_ylim only takes np.float64s
+    # It turns out that set_ylim only takes float64s
     for sample_id, subplot in enumerate(ax_list):
         localYMin = yMin[sample_id % len(yMin)]
         localYMax = yMax[sample_id % len(yMax)]
         lims = [globalYmin, globalYmax]
         if localYMin:
             if localYMax:
-                lims = (np.float64(localYMin), np.float64(localYMax))
+                lims = (float64(localYMin), float64(localYMax))
             else:
-                lims = (np.float64(localYMin), lims[1])
+                lims = (float64(localYMin), lims[1])
         elif localYMax:
-            lims = (lims[0], np.float64(localYMax))
+            lims = (lims[0], float64(localYMax))
         if lims[0] >= lims[1]:
             lims = (lims[0], lims[0] + 1)
         ax_list[sample_id].set_ylim(lims)

--- a/deeptools/plotHeatmap.py
+++ b/deeptools/plotHeatmap.py
@@ -180,7 +180,7 @@ def addProfilePlot(hm, plt, fig, grids, iterNum, iterNum2, perGroup, averageType
         ticks[0].label1.set_horizontalalignment('left')
         ticks[-1].label1.set_horizontalalignment('right')
 
-        globalYmin = min(float64(globalYmin), ax_profile.get_ylim()[0])
+        globalYmin = min(float(globalYmin), ax_profile.get_ylim()[0])
         globalYmax = max(globalYmax, ax_profile.get_ylim()[1])
 
     # It turns out that set_ylim only takes float64s
@@ -190,11 +190,11 @@ def addProfilePlot(hm, plt, fig, grids, iterNum, iterNum2, perGroup, averageType
         lims = [globalYmin, globalYmax]
         if localYMin:
             if localYMax:
-                lims = (float64(localYMin), float64(localYMax))
+                lims = (float(localYMin), float(localYMax))
             else:
-                lims = (float64(localYMin), lims[1])
+                lims = (float(localYMin), lims[1])
         elif localYMax:
-            lims = (lims[0], float64(localYMax))
+            lims = (lims[0], float(localYMax))
         if lims[0] >= lims[1]:
             lims = (lims[0], lims[0] + 1)
         ax_list[sample_id].set_ylim(lims)

--- a/deeptools/plotProfile.py
+++ b/deeptools/plotProfile.py
@@ -750,7 +750,7 @@ class Profile(object):
                             self.color_list[coloridx],
                             label,
                             plot_type=self.plot_type)
-            globalYmin = min(np.float64(globalYmin), ax.get_ylim()[0])
+            globalYmin = min(float64(globalYmin), ax.get_ylim()[0])
             globalYmax = max(globalYmax, ax.get_ylim()[1])
 
             # Exclude ticks from all but one subplot by default
@@ -783,18 +783,18 @@ class Profile(object):
                     first = False
             ax_list.append(ax)
 
-        # It turns out that set_ylim only takes np.float64s
+        # It turns out that set_ylim only takes float64s
         for sample_id, subplot in enumerate(ax_list):
             localYMin = self.y_min[sample_id % len(self.y_min)]
             localYMax = self.y_max[sample_id % len(self.y_max)]
             lims = [globalYmin, globalYmax]
             if localYMin is not None:
                 if localYMax is not None:
-                    lims = (np.float64(localYMin), np.float64(localYMax))
+                    lims = (float64(localYMin), float64(localYMax))
                 else:
-                    lims = (np.float64(localYMin), lims[1])
+                    lims = (float64(localYMin), lims[1])
             elif localYMax is not None:
-                lims = (lims[0], np.float64(localYMax))
+                lims = (lims[0], float64(localYMax))
             if lims[0] >= lims[1]:
                 lims = (lims[0], lims[0] + 1)
             ax_list[sample_id].set_ylim(lims)

--- a/deeptools/plotProfile.py
+++ b/deeptools/plotProfile.py
@@ -750,7 +750,7 @@ class Profile(object):
                             self.color_list[coloridx],
                             label,
                             plot_type=self.plot_type)
-            globalYmin = min(float64(globalYmin), ax.get_ylim()[0])
+            globalYmin = min(float(globalYmin), ax.get_ylim()[0])
             globalYmax = max(globalYmax, ax.get_ylim()[1])
 
             # Exclude ticks from all but one subplot by default
@@ -790,11 +790,11 @@ class Profile(object):
             lims = [globalYmin, globalYmax]
             if localYMin is not None:
                 if localYMax is not None:
-                    lims = (float64(localYMin), float64(localYMax))
+                    lims = (float(localYMin), float(localYMax))
                 else:
-                    lims = (float64(localYMin), lims[1])
+                    lims = (float(localYMin), lims[1])
             elif localYMax is not None:
-                lims = (lims[0], float64(localYMax))
+                lims = (lims[0], float(localYMax))
             if lims[0] >= lims[1]:
                 lims = (lims[0], lims[0] + 1)
             ax_list[sample_id].set_ylim(lims)

--- a/deeptools/sumCoveragePerBin.py
+++ b/deeptools/sumCoveragePerBin.py
@@ -90,7 +90,7 @@ class SumCoveragePerBin(countReadsPerBin.CountReadsPerBin):
             except:
                 # bigWig input, as used by plotFingerprint
                 if bamHandle.chroms(chrom):
-                    _ = np.array(bamHandle.stats(chrom, regStart, regEnd, type="mean", nBins=nRegBins), dtype=np.float64)
+                    _ = np.array(bamHandle.stats(chrom, regStart, regEnd, type="mean", nBins=nRegBins), dtype=float64)
                     _[np.isnan(_)] = 0.0
                     _ = _ * tileSize
                     coverages += _

--- a/deeptools/sumCoveragePerBin.py
+++ b/deeptools/sumCoveragePerBin.py
@@ -90,7 +90,7 @@ class SumCoveragePerBin(countReadsPerBin.CountReadsPerBin):
             except:
                 # bigWig input, as used by plotFingerprint
                 if bamHandle.chroms(chrom):
-                    _ = np.array(bamHandle.stats(chrom, regStart, regEnd, type="mean", nBins=nRegBins), dtype=float64)
+                    _ = np.array(bamHandle.stats(chrom, regStart, regEnd, type="mean", nBins=nRegBins), dtype=float)
                     _[np.isnan(_)] = 0.0
                     _ = _ * tileSize
                     coverages += _


### PR DESCRIPTION
bugfix (https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations)

deprecation warning is to fall as error is to winter

converted cases of aliased np.int to base int
converted cases of aliased np.float64 to base float64
