### PR TITLE
Fix error handling

### DIFF
--- a/deeptools/writeBedGraph_bam_and_bw.py
+++ b/deeptools/writeBedGraph_bam_and_bw.py
@@ -23,7 +23,7 @@ def getCoverageFromBigwig(bigwigHandle, chrom, start, end, tileSize,
                           missingDataAsZero=False):
     try:
         coverage = np.asarray(bigwigHandle.values(chrom, start, end))
-    except TypeError:
+    except RuntimeError:
         # this error happens when chromosome
         # is not into the bigwig file
         return []


### PR DESCRIPTION
I got an error when using bigwigAverage: 
```
Traceback (most recent call last):
  File "/data/galaxy/galaxy/var/dependencies/_conda/envs/mulled-v1-9dd4e5433cf4f47ee04cca722ff3869495cfcd627aecb78c70b6dcb65b45e293/bin/bigwigAverage", line 12, in <module>
    main(args)
  File "/data/galaxy/galaxy/var/dependencies/_conda/envs/mulled-v1-9dd4e5433cf4f47ee04cca722ff3869495cfcd627aecb78c70b6dcb65b45e293/lib/python3.8/site-packages/deeptools/bigwigAverage.py", line 140, in main
    writeBedGraph_bam_and_bw.writeBedGraph(
  File "/data/galaxy/galaxy/var/dependencies/_conda/envs/mulled-v1-9dd4e5433cf4f47ee04cca722ff3869495cfcd627aecb78c70b6dcb65b45e293/lib/python3.8/site-packages/deeptools/writeBedGraph_bam_and_bw.py", line 209, in writeBedGraph
    res = mapReduce.mapReduce((tileSize, fragmentLength, bamOrBwFileList,
  File "/data/galaxy/galaxy/var/dependencies/_conda/envs/mulled-v1-9dd4e5433cf4f47ee04cca722ff3869495cfcd627aecb78c70b6dcb65b45e293/lib/python3.8/site-packages/deeptools/mapReduce.py", line 146, in mapReduce
    res = list(map(func, TASKS))
  File "/data/galaxy/galaxy/var/dependencies/_conda/envs/mulled-v1-9dd4e5433cf4f47ee04cca722ff3869495cfcd627aecb78c70b6dcb65b45e293/lib/python3.8/site-packages/deeptools/writeBedGraph_bam_and_bw.py", line 42, in writeBedGraph_wrapper
    return writeBedGraph_worker(*args)
  File "/data/galaxy/galaxy/var/dependencies/_conda/envs/mulled-v1-9dd4e5433cf4f47ee04cca722ff3869495cfcd627aecb78c70b6dcb65b45e293/lib/python3.8/site-packages/deeptools/writeBedGraph_bam_and_bw.py", line 74, in writeBedGraph_worker
    getCoverageFromBigwig(
  File "/data/galaxy/galaxy/var/dependencies/_conda/envs/mulled-v1-9dd4e5433cf4f47ee04cca722ff3869495cfcd627aecb78c70b6dcb65b45e293/lib/python3.8/site-packages/deeptools/writeBedGraph_bam_and_bw.py", line 25, in getCoverageFromBigwig
    coverage = np.asarray(bigwigHandle.values(chrom, start, end))
RuntimeError: Invalid interval bounds!
```
I think it is because in the code there is a except ValueError instead of RuntimeError. The switch in pyBigwig occured in https://github.com/deeptools/pyBigWig/commit/17f8dab0d132975ade2cd3d9a755e8f3820940ca which has been merged in version 0.2.1...

 - [ ] Does the PR contain new feature?
 - [X] Does the PR contain bugfix?
 - [ ] Does the PR contain documentation changes?
 - [ ] Does the PR contain changes to the galaxy wrapper?
