### PR TITLE
Do not use Tick.label

### DIFF
--- a/deeptools/correlation.py
+++ b/deeptools/correlation.py
@@ -503,8 +503,9 @@ class Correlation:
                 top=False,
                 bottom=False,
                 direction='out')
-            for tick in ax.xaxis.get_major_ticks():
-                tick.label.set_rotation(45)
+            ax.get_xaxis().set_tick_params(
+                which='major',
+                labelrotation=45)
 
             if col != num_samples - 1:
                 ax.set_yticklabels([])
@@ -522,8 +523,9 @@ class Correlation:
                     top=False,
                     bottom=True,
                     direction='out')
-                for tick in ax.xaxis.get_major_ticks():
-                    tick.label.set_rotation(45)
+                ax.get_xaxis().set_tick_params(
+                    which='major',
+                    labelrotation=45)
 
             else:
                 ax.set_xticklabels([])


### PR DESCRIPTION
To support matplotlib 3.8.0:
https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.8.0.html#unused-methods-in-axis-tick-xaxis-and-yaxis

This was spotted by the galaxy tool:
https://github.com/deeptools/deepTools/actions/runs/6305763719/job/17120046090?pr=1257
```
Job in error state.. tool_id: deeptools_plot_correlation, exit_code: 1, stderr: Traceback (most recent call last):
  File "/usr/share/miniconda3/envs/test_and_build/bin/plotCorrelation", line 8, in <module>
    sys.exit(main())
  File "/usr/share/miniconda3/envs/test_and_build/lib/python3.10/site-packages/deeptools/plotCorrelation.py", line 244, in main
    corr.plot_scatter(args.plotFile,
  File "/usr/share/miniconda3/envs/test_and_build/lib/python3.10/site-packages/deeptools/correlation.py", line 507, in plot_scatter
    tick.label.set_rotation(45)
AttributeError: 'XTick' object has no attribute 'label'. Did you mean: '_label'?
.
```