### PR TITLE
Add version constraint to maturin requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "maturin"
+    "maturin>=1.0,<2.0"
 ]
 build-backend = "maturin"
 


### PR DESCRIPTION
As suggested by maturin itself:

Warning: Please use maturin in pyproject.toml with a version constraint, e.g. `requires = ["maturin>=1.0,<2.0"]`. This will become an error.
