### PR TITLE
Provide build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 requires = [
     "setuptools"
 ]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "deepTools"


### PR DESCRIPTION
According to https://setuptools.pypa.io/en/latest/userguide/quickstart.html#basic-use, each package must provide a `pyproject.toml` (available) and specify a `build-backend` (missing).

This commit adds the build backend to `pyproject.toml`

**Welcome to deepTools GitHub repository! Please check the following regarding
your pull request :**

 - [ ] Does the PR contain new feature?
 - [x] Does the PR contain bugfix?
 - [ ] Does the PR contain documentation changes?
 - [ ] Does the PR contain changes to the galaxy wrapper?
