### PR TITLE
added support for warnings stdlib

### DIFF
--- a/deeptools/SES_scaleFactor.py
+++ b/deeptools/SES_scaleFactor.py
@@ -3,6 +3,8 @@
 
 import os
 import numpy as np
+import warnings
+np.warnings = warnings
 
 # own packages
 from deeptools import bamHandler

--- a/deeptools/bamCompare.py
+++ b/deeptools/bamCompare.py
@@ -3,6 +3,8 @@
 
 import argparse  # to parse command line arguments
 import numpy as np
+import warnings
+np.warnings = warnings
 import sys
 
 # my packages

--- a/deeptools/bamCoverage.py
+++ b/deeptools/bamCoverage.py
@@ -5,6 +5,8 @@
 import argparse
 import sys
 import numpy as np
+import warnings
+np.warnings = warnings
 from deeptools import writeBedGraph  # This should be made directly into a bigWig
 from deeptools import parserCommon
 from deeptools.getScaleFactor import get_scale_factor

--- a/deeptools/bamPEFragmentSize.py
+++ b/deeptools/bamPEFragmentSize.py
@@ -4,6 +4,8 @@
 import argparse
 import sys
 import numpy as np
+import warnings
+np.warnings = warnings
 
 import matplotlib
 matplotlib.use('Agg')

--- a/deeptools/bigwigAverage.py
+++ b/deeptools/bigwigAverage.py
@@ -3,6 +3,8 @@
 import argparse
 import sys
 import numpy as np
+import warnings
+np.warnings = warnings
 from deeptools import parserCommon
 from deeptools import writeBedGraph_bam_and_bw
 

--- a/deeptools/computeGCBias.py
+++ b/deeptools/computeGCBias.py
@@ -5,6 +5,8 @@ import time
 
 import multiprocessing
 import numpy as np
+import warnings
+np.warnings = warnings
 import argparse
 from scipy.stats import poisson
 import py2bit

--- a/deeptools/computeMatrixOperations.py
+++ b/deeptools/computeMatrixOperations.py
@@ -2,6 +2,8 @@
 import deeptools.heatmapper as heatmapper
 import deeptoolsintervals.parse as dti
 import numpy as np
+import warnings
+np.warnings = warnings
 import argparse
 import sys
 import os

--- a/deeptools/correctGCBias.py
+++ b/deeptools/correctGCBias.py
@@ -11,6 +11,8 @@ import py2bit
 import pysam
 import multiprocessing
 import numpy as np
+import warnings
+np.warnings = warnings
 import argparse
 
 from scipy.stats import binom

--- a/deeptools/correlation.py
+++ b/deeptools/correlation.py
@@ -2,6 +2,8 @@ import sys
 import itertools
 import copy
 import numpy as np
+import warnings
+np.warnings = warnings
 import scipy.cluster.hierarchy as sch
 import scipy.stats
 import matplotlib as mpl

--- a/deeptools/correlation_heatmap.py
+++ b/deeptools/correlation_heatmap.py
@@ -3,6 +3,8 @@ mplt_use('Agg')
 from deeptools import cm  # noqa: F401
 import matplotlib.pyplot as plt
 import numpy as np
+import warnings
+np.warnings = warnings
 import scipy.cluster.hierarchy as sch
 from matplotlib import rcParams
 import matplotlib.colors as pltcolors

--- a/deeptools/countReadsPerBin.py
+++ b/deeptools/countReadsPerBin.py
@@ -4,6 +4,8 @@ import time
 import sys
 import multiprocessing
 import numpy as np
+import warnings
+np.warnings = warnings
 
 # deepTools packages
 import deeptools.utilities

--- a/deeptools/getFragmentAndReadSize.py
+++ b/deeptools/getFragmentAndReadSize.py
@@ -1,4 +1,6 @@
 import numpy as np
+import warnings
+np.warnings = warnings
 
 # own tools
 from deeptools import bamHandler

--- a/deeptools/getRatio.py
+++ b/deeptools/getRatio.py
@@ -1,4 +1,6 @@
 import numpy as np
+import warnings
+np.warnings = warnings
 
 old_settings = np.seterr(all='ignore')
 

--- a/deeptools/getScaleFactor.py
+++ b/deeptools/getScaleFactor.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
+import warnings
+np.warnings = warnings
 import deeptools.mapReduce as mapReduce
 from deeptools import bamHandler
 from deeptools import utilities

--- a/deeptools/getScorePerBigWigBin.py
+++ b/deeptools/getScorePerBigWigBin.py
@@ -1,5 +1,7 @@
 import pyBigWig
 import numpy as np
+import warnings
+np.warnings = warnings
 import os
 import sys
 import shutil

--- a/deeptools/heatmapper.py
+++ b/deeptools/heatmapper.py
@@ -2,6 +2,8 @@ import sys
 import gzip
 from collections import OrderedDict
 import numpy as np
+import warnings
+np.warnings = warnings
 from copy import deepcopy
 
 import pyBigWig

--- a/deeptools/heatmapper_utilities.py
+++ b/deeptools/heatmapper_utilities.py
@@ -1,4 +1,6 @@
 import numpy as np
+import warnings
+np.warnings = warnings
 import matplotlib
 matplotlib.use('Agg')
 matplotlib.rcParams['pdf.fonttype'] = 42

--- a/deeptools/multiBamSummary.py
+++ b/deeptools/multiBamSummary.py
@@ -5,6 +5,8 @@ import os
 import sys
 import argparse
 import numpy as np
+import warnings
+np.warnings = warnings
 
 import deeptools.countReadsPerBin as countR
 from deeptools import parserCommon

--- a/deeptools/multiBigwigSummary.py
+++ b/deeptools/multiBigwigSummary.py
@@ -5,6 +5,8 @@ import sys
 import argparse
 import os.path
 import numpy as np
+import warnings
+np.warnings = warnings
 from deeptools import parserCommon
 from deeptools.utilities import smartLabels
 import deeptools.getScorePerBigWigBin as score_bw

--- a/deeptools/plotCorrelation.py
+++ b/deeptools/plotCorrelation.py
@@ -4,6 +4,8 @@
 import sys
 import argparse
 import numpy as np
+import warnings
+np.warnings = warnings
 import matplotlib
 matplotlib.use('Agg')
 matplotlib.rcParams['pdf.fonttype'] = 42

--- a/deeptools/plotCoverage.py
+++ b/deeptools/plotCoverage.py
@@ -5,6 +5,8 @@ import os
 import sys
 import argparse
 import numpy as np
+import warnings
+np.warnings = warnings
 
 import matplotlib
 matplotlib.use('Agg')

--- a/deeptools/plotEnrichment.py
+++ b/deeptools/plotEnrichment.py
@@ -4,6 +4,8 @@
 import sys
 import argparse
 import numpy as np
+import warnings
+np.warnings = warnings
 import matplotlib
 matplotlib.use('Agg')
 matplotlib.rcParams['pdf.fonttype'] = 42

--- a/deeptools/plotFingerprint.py
+++ b/deeptools/plotFingerprint.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
+import warnings
+np.warnings = warnings
 import argparse
 import sys
 import matplotlib

--- a/deeptools/plotHeatmap.py
+++ b/deeptools/plotHeatmap.py
@@ -5,6 +5,8 @@ from __future__ import division
 import argparse
 from collections import OrderedDict
 import numpy as np
+import warnings
+np.warnings = warnings
 import matplotlib
 matplotlib.use('Agg')
 matplotlib.rcParams['pdf.fonttype'] = 42

--- a/deeptools/plotProfile.py
+++ b/deeptools/plotProfile.py
@@ -6,6 +6,8 @@ import sys
 
 import argparse
 import numpy as np
+import warnings
+np.warnings = warnings
 from math import ceil
 import matplotlib
 matplotlib.use('Agg')

--- a/deeptools/sumCoveragePerBin.py
+++ b/deeptools/sumCoveragePerBin.py
@@ -1,4 +1,6 @@
 import numpy as np
+import warnings
+np.warnings = warnings
 import multiprocessing
 import time
 

--- a/deeptools/test/test_bigwigCompare_and_multiBigwigSummary.py
+++ b/deeptools/test/test_bigwigCompare_and_multiBigwigSummary.py
@@ -1,6 +1,8 @@
 import deeptools.bigwigCompare as bwComp
 import deeptools.multiBigwigSummary as bwCorr
 import numpy as np
+import warnings
+np.warnings = warnings
 import numpy.testing as nt
 
 import os.path

--- a/deeptools/test/test_countReadsPerBin.py
+++ b/deeptools/test/test_countReadsPerBin.py
@@ -2,6 +2,8 @@
 
 import deeptools.countReadsPerBin as cr
 import numpy as np
+import warnings
+np.warnings = warnings
 import numpy.testing as nt
 import os.path
 import pytest

--- a/deeptools/test/test_multiBamSummary.py
+++ b/deeptools/test/test_multiBamSummary.py
@@ -1,5 +1,7 @@
 import deeptools.multiBamSummary as mbs
 import numpy as np
+import warnings
+np.warnings = warnings
 import numpy.testing as nt
 
 import os.path

--- a/deeptools/utilities.py
+++ b/deeptools/utilities.py
@@ -6,6 +6,8 @@ import matplotlib as mpl
 mpl.use('Agg')
 from deeptools import cm  # noqa: F401
 import numpy as np
+import warnings
+np.warnings = warnings
 
 
 debug = 0

--- a/deeptools/writeBedGraph.py
+++ b/deeptools/writeBedGraph.py
@@ -2,6 +2,8 @@ import os
 import sys
 import shutil
 import numpy as np
+import warnings
+np.warnings = warnings
 import pyBigWig
 
 # own modules

--- a/deeptools/writeBedGraph_bam_and_bw.py
+++ b/deeptools/writeBedGraph_bam_and_bw.py
@@ -5,6 +5,8 @@ import os
 import shutil
 import tempfile
 import numpy as np
+import warnings
+np.warnings = warnings
 import sys
 
 # NGS packages


### PR DESCRIPTION
**Welcome to deepTools GitHub repository! Please check the following regarding
your pull request :**

 - [x] Does the PR contain new feature?
 - [X] Does the PR contain bugfix?
An error was raising while using `computeMatrixOperations filterValues` on NumPy version 1.26.4. I think NumPy deleted the link to the warnings stdlib as of version 1.21.5 ([See stackoverflow thread](https://stackoverflow.com/questions/76246578/module-numpy-has-no-attribute-warnings)). Therefore, the script computeMatrixOperations.py fails on line 432, raising:

```
np.warnings.filterwarnings('ignore')
AttributeError: module 'numpy' has no attribute 'warnings'. Did you mean: 'hanning'?
```

Therefore, based on the same stackoverflow thread I modified all the files importing numpy to add support for warnings. The other option is to comment the line 432 as suggested in #1358 .

 - [x] Does the PR contain documentation changes?
 - [x] Does the PR contain changes to the galaxy wrapper?
