### PR TITLE
Fixed erroneous args.args in silhouette option of plotHeatmap.py

### DIFF
--- a/deeptools/plotHeatmap.py
+++ b/deeptools/plotHeatmap.py
@@ -855,7 +855,7 @@ def main(args=None):
         if args.kmeans is not None:
             hm.matrix.computeSilhouette(args.kmeans)
         elif args.hclust is not None:
-            hm.matrix.computeSilhouette(args.args.hclust)
+            hm.matrix.computeSilhouette(args.hclust)
 
     if args.outFileNameMatrix:
         hm.save_matrix(args.outFileNameMatrix)


### PR DESCRIPTION
**Welcome to deepTools GitHub repository! Please check the following regarding
your pull request :**

 - [ ] Does the PR contain new feature?
 - [ X ] Does the PR contain bugfix?
 - [ ] Does the PR contain documentation changes?
 - [ ] Does the PR contain changes to the galaxy wrapper?

Quick fix to get plotHeatmap --silhouette to work with --hclust. 