### PR TITLE
plotHeatmap: add --plotColors argument for profile plot line colors

### DIFF
--- a/deeptools/parserCommon.py
+++ b/deeptools/parserCommon.py
@@ -2,6 +2,7 @@ import argparse
 import os
 from importlib.metadata import version
 import multiprocessing
+import matplotlib.colors
 
 
 def check_float_0_1(value):
@@ -19,6 +20,15 @@ def check_list_of_comma_values(value):
         if len(foo) < 2:
             raise argparse.ArgumentTypeError("%s is an invalid element of a list of comma separated values. "
                                              "Only argument elements of the following form are accepted: 'foo,bar'" % foo)
+    return value
+
+
+def check_color(value):
+    """Validate that a string is a recognised matplotlib color (named or hex)."""
+    if not matplotlib.colors.is_color_like(value):
+        raise argparse.ArgumentTypeError(
+            "'{}' is not a valid matplotlib color. Use a named color "
+            "(e.g. 'red') or a hex value (e.g. '#ff0000').".format(value))
     return value
 
 
@@ -703,6 +713,17 @@ def heatmapperOptionalArgs(mode=['heatmap', 'profile'][0]):
             'between the colors.',
             type=int,
             default=256)
+
+        optional.add_argument(
+            '--plotColors',
+            help='Colors for the profile lines in the summary plot shown above the heatmap. '
+                 'Only applies when --whatToShow is set to "plot, heatmap and colorbar" or '
+                 '"plot and heatmap". One color per group (or per sample when --perGroup is set) '
+                 'can be specified. Colors are recycled if fewer are given than the number of lines. '
+                 'Accepts named matplotlib colors (e.g. red, blue) and hex values (e.g. #ff0000). '
+                 'Example: --plotColors red blue green',
+            type=check_color,
+            nargs='+')
 
         optional.add_argument('--zMin', '-min',
                               default=None,

--- a/deeptools/plotHeatmap.py
+++ b/deeptools/plotHeatmap.py
@@ -379,7 +379,7 @@ def plotlyMatrix(hm,
 
 
 def plotMatrix(hm, outFileName,
-               colorMapDict={'colorMap': ['binary'], 'missingDataColor': 'black', 'alpha': 1.0},
+               colorMapDict={'colorMap': ['binary'], 'missingDataColor': 'black', 'alpha': 1.0, 'plotColors': None},
                plotTitle='',
                xAxisLabel='', yAxisLabel='', regionsLabel='',
                zMin=None, zMax=None,
@@ -531,13 +531,24 @@ def plotMatrix(hm, outFileName,
         fig
     )
 
-    # color map for the summary plot (profile) on top of the heatmap
-    cmap_plot = plt.get_cmap('jet')
+    # colors for the profile lines in the summary plot above the heatmap
     numgroups = hm.matrix.get_num_groups()
-    if perGroup:
-        color_list = cmap_plot(np.arange(hm.matrix.get_num_samples()) / hm.matrix.get_num_samples())
+    if colorMapDict.get('plotColors'):
+        # user-supplied colors: one per group (or per sample when perGroup),
+        # recycled with modulo if fewer colors are given than lines
+        user_colors = colorMapDict['plotColors']
+        if perGroup:
+            n_lines = hm.matrix.get_num_samples()
+        else:
+            n_lines = numgroups
+        color_list = [user_colors[i % len(user_colors)] for i in range(n_lines)]
     else:
-        color_list = cmap_plot(np.arange(numgroups) / numgroups)
+        # default: evenly-spaced colors from the jet colormap
+        cmap_plot = plt.get_cmap('jet')
+        if perGroup:
+            color_list = cmap_plot(np.arange(hm.matrix.get_num_samples()) / hm.matrix.get_num_samples())
+        else:
+            color_list = cmap_plot(np.arange(numgroups) / numgroups)
     alpha = colorMapDict['alpha']
     if image_format == 'plotly':
         return plotlyMatrix(hm,
@@ -867,7 +878,8 @@ def main(args=None):
                      'colorList': args.colorList,
                      'colorNumber': args.colorNumber,
                      'missingDataColor': args.missingDataColor,
-                     'alpha': args.alpha}
+                     'alpha': args.alpha,
+                     'plotColors': args.plotColors}
 
     plotMatrix(hm,
                args.outFileName,


### PR DESCRIPTION
Allows users to set custom colors for the profile/summary plot lines when --whatToShow includes a plot. Colors are recycled if fewer are given than the number of lines. Accepts any matplotlib named color or hex value. Consistent with the existing --colorList approach.

Related to issue https://github.com/deeptools/deepTools/issues/1166.

Examples of how it works:
```shell
plotHeatmap -m matrix.gz \
	-out test1.png \
	--regionsLabel "Region1" "Region2" "Region3" "Region4" \
	--samplesLabel "WT" "KO" \
	--whatToShow "plot, heatmap and colorbar" \
	--perGroup \
	--heatmapHeight 10 \
	--heatmapWidth 5 \
	--colorMap viridis \
	--plotColors "#cccccc" "#dd3b3b"
```
<img width="1610" height="1027" alt="test1" src="https://github.com/user-attachments/assets/a4e31ed6-5473-4f82-92fe-a8d9c4afa5af" />

Falls back to standard colours, if `--plotColors` is not used:

```shell
plotHeatmap -m matrix.gz \
	-out test2.png \
	--regionsLabel "Region1" "Region2" "Region3" "Region4" \
	--samplesLabel "WT" "KO" \
	--whatToShow "plot, heatmap and colorbar" \
	--perGroup \
	--heatmapHeight 10 \
	--heatmapWidth 5 \
	--colorMap viridis
```
<img width="1610" height="1027" alt="test2" src="https://github.com/user-attachments/assets/bf90c712-8e81-4332-91a8-6f5158b360e9" />

Compatible with colour recycling:

```shell
plotHeatmap -m matrix.gz \
	-out test3.png \
	--regionsLabel "Region1" "Region2" "Region3" "Region4" \
	--samplesLabel "WT" "KO" \
	--whatToShow "plot, heatmap and colorbar" \
	--perGroup \
	--heatmapHeight 10 \
	--heatmapWidth 5 \
	--colorMap viridis \
	--plotColors "#cccccc"
```
<img width="1610" height="1027" alt="test3" src="https://github.com/user-attachments/assets/b409efc1-a53f-4144-8e4d-b71c4f6dc44f" />

Error message when invalid colour values are used:

```console
plotHeatmap -m matrix.gz \
	-out test4.png \
	--regionsLabel "Region1" "Region2" "Region3" "Region4" \
	--samplesLabel "WT" "KO" \
	--whatToShow "plot and heatmap" \
	--perGroup \
	--heatmapHeight 10 \
	--heatmapWidth 5 \
	--colorMap viridis \
	--plotColors notacolor alsonotacolor
usage: plotHeatmap -m matrix.gz
help: plotHeatmap -h / plotHeatmap --help
plotHeatmap: error: argument --plotColors: 'notacolor' is not a valid matplotlib color. Use a named color (e.g. 'red') or a hex value (e.g. '#ff0000').
```