### PR TITLE
Add tests: bamCoverage RPKM/scaleFactor, alignmentSieve fragment/strand filters

### DIFF
--- a/pydeeptools/deeptools/test/test_alignmentseive.py
+++ b/pydeeptools/deeptools/test/test_alignmentseive.py
@@ -37,6 +37,45 @@ def test_minimum_mapping_quality_filter_metric():
     unlink(filter_metric_file)
 
 
+def test_fragment_length_filter_metric():
+    """
+    Test --minFragmentLength / --maxFragmentLength filtering (fragment-size
+    selection, e.g. nucleosome-free vs mono-nucleosome). Only read pairs whose
+    template length falls in [130, 200] are kept.
+    """
+    outfile = '/tmp/test_bam.bam'
+    filter_metric_file = '/tmp/test_metrics.txt'
+    args = "--bam {} -o {} --minFragmentLength 130 --maxFragmentLength 200 --filterMetrics {}".format(BAMFILE_IN, outfile, filter_metric_file).split()
+    aln_seive.main(args)
+
+    _foo = open(filter_metric_file, "r")
+    resp = _foo.readlines()[2]
+    _foo.close()
+    expected = 'paired_chr2L.bam\t7933\t12644\n'
+    assert expected in resp, f"'{expected}' not found in '{resp}'"
+    unlink(outfile)
+    unlink(filter_metric_file)
+
+
+def test_filterRNAstrand_forward_filter_metric():
+    """
+    Test --filterRNAstrand forward (keep only reads matching the forward
+    transcription strand, using paired-end mate orientation).
+    """
+    outfile = '/tmp/test_bam.bam'
+    filter_metric_file = '/tmp/test_metrics.txt'
+    args = "--bam {} -o {} --filterRNAstrand forward --filterMetrics {}".format(BAMFILE_IN, outfile, filter_metric_file).split()
+    aln_seive.main(args)
+
+    _foo = open(filter_metric_file, "r")
+    resp = _foo.readlines()[2]
+    _foo.close()
+    expected = 'paired_chr2L.bam\t6303\t12644\n'
+    assert expected in resp, f"'{expected}' not found in '{resp}'"
+    unlink(outfile)
+    unlink(filter_metric_file)
+
+
 def test_with_bed_output_along_with_shifts():
     """
     Tests Alignment seive with shifts and output BED file

--- a/pydeeptools/deeptools/test/test_bamCoverage_and_bamCompare.py
+++ b/pydeeptools/deeptools/test/test_bamCoverage_and_bamCompare.py
@@ -96,6 +96,43 @@ def test_bam_coverage_skipnas():
         unlink(outfile)
 
 
+def test_bam_coverage_normalizeUsingRPKM():
+    """
+    Test --normalizeUsing RPKM. testB.bam has 4 reads (2 bp genome coverage per
+    read), so each covered read contributes 1e9 / (binLength_kb * totalReads)
+    reads-per-kilobase-per-million.
+    """
+    outfile = '/tmp/test_file.bg'
+    for fname in [BAMFILE_B]:
+        args = "--bam {} -o {} --outFileFormat bedgraph --normalizeUsing RPKM".format(fname, outfile).split()
+        bam_cov.main(args)
+
+        _foo = open(outfile, 'r')
+        resp = _foo.readlines()
+        _foo.close()
+        expected = ['3R\t0\t50\t0\n', '3R\t50\t150\t5000000\n', '3R\t150\t200\t10000000\n']
+        assert f"{resp}" == f"{expected}", f"{resp} != {expected}"
+        unlink(outfile)
+
+
+def test_bam_coverage_scaleFactor():
+    """
+    Test --scaleFactor. A manual scale factor is applied directly to the raw
+    coverage (and takes precedence over --normalizeUsing).
+    """
+    outfile = '/tmp/test_file.bg'
+    for fname in [BAMFILE_B]:
+        args = "--bam {} -o {} --outFileFormat bedgraph --scaleFactor 2.0".format(fname, outfile).split()
+        bam_cov.main(args)
+
+        _foo = open(outfile, 'r')
+        resp = _foo.readlines()
+        _foo.close()
+        expected = ['3R\t0\t50\t0\n', '3R\t50\t150\t2\n', '3R\t150\t200\t4\n']
+        assert f"{resp}" == f"{expected}", f"{resp} != {expected}"
+        unlink(outfile)
+
+
 # def test_bam_coverage_filtering():
 #     outfile = '/tmp/test_file.bg'
 #     #for fname in [BAMFILE_B, CRAMFILE_B]:


### PR DESCRIPTION
Fills coverage gaps surfaced while triaging the stalled #1369 tests (the direct-Rust-binding versions couldn't be salvaged, but two of their *ideas* covered untested paths).

**bamCoverage** (`test_bamCoverage_and_bamCompare.py`)
- `--normalizeUsing RPKM` — RPKM was untested; the suite only covered CPM and RPGC.
- `--scaleFactor` — manual scale factor (also documents that it takes precedence over `--normalizeUsing`).

**alignmentSieve** (`test_alignmentseive.py`)
- `--minFragmentLength` / `--maxFragmentLength` — fragment-size selection was untested.
- `--filterRNAstrand forward` — not exercised anywhere in the suite.

Expected values were derived by running the current tools; assertions use the existing filterMetrics/bedgraph style. Verified locally: `pixi run pytest` on both files → 26 passed (22 existing + 4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)