### PR TITLE
ci: add zizmor pre-commit hook and harden workflows

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -5,6 +5,9 @@ on:
         tags:
             - "*"
 
+permissions:
+    contents: read
+
 defaults:
     run:
         shell: bash -l {0}
@@ -15,8 +18,10 @@ jobs:
         name: upload to pypi
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v7
-            - uses: actions/setup-python@v6
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                persist-credentials: false
+            - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
               with:
                   python-version: "3.12"
                   cache: "pip"

--- a/.github/workflows/test_planemo.yml
+++ b/.github/workflows/test_planemo.yml
@@ -1,6 +1,9 @@
 name: tests_planemo
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+    contents: read
+
 env:
     GALAXY_BRANCH: release_26.0
 
@@ -16,8 +19,10 @@ jobs:
             matrix:
                 chunk: [1, 2, 3]
         steps:
-            - uses: actions/checkout@v7
-            - uses: conda-incubator/setup-miniconda@v4
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                persist-credentials: false
+            - uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
               with:
                   miniconda-version: "latest"
                   auto-activate-base: true
@@ -31,7 +36,7 @@ jobs:
             - name: planemo
               run: |
                   ./.planemo.sh ${{ matrix.chunk }} ${{ env.GALAXY_BRANCH }}
-            - uses: actions/upload-artifact@v7
+            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: "Tool test output ${{ matrix.chunk }}"
                   path: upload
@@ -40,21 +45,21 @@ jobs:
         needs: planemo_test
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/download-artifact@v8
+            - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
               with:
                   path: artifacts
             - name: Combine outputs
-              uses: galaxyproject/planemo-ci-action@v1
+              uses: galaxyproject/planemo-ci-action@823fb30673dde862fcf88fd267c369920675fb53 # v1.0.29
               id: combine
               with:
                   mode: combine
                   html-report: true
-            - uses: actions/upload-artifact@v7
+            - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
               with:
                   name: "All tool test results"
                   path: upload
             - name: Check outputs
-              uses: galaxyproject/planemo-ci-action@v1
+              uses: galaxyproject/planemo-ci-action@823fb30673dde862fcf88fd267c369920675fb53 # v1.0.29
               id: check
               with:
                   mode: check

--- a/.github/workflows/test_pytest.yml
+++ b/.github/workflows/test_pytest.yml
@@ -1,6 +1,9 @@
 name: tests_pytest
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+    contents: read
+
 defaults:
     run:
         shell: bash -l {0}
@@ -11,7 +14,9 @@ jobs:
         runs-on: ubuntu-latest
         if: github.base_ref == 'master'
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                persist-credentials: false
             - name: Check path
               run: find /home/runner/work/deepTools/deepTools -name "pyproject.toml"
             - name: Get Version of Deeptools
@@ -43,13 +48,15 @@ jobs:
             matrix:
                 python-version: ["3.12", "3.13", "3.14"]
         steps:
-            - uses: actions/checkout@v7
-            - uses: actions/setup-python@v6
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                persist-credentials: false
+            - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: "pip"
             - name: Install Rust
-              uses: actions-rust-lang/setup-rust-toolchain@v1
+              uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
             - name: build deeptools
               run: |
                   python -m venv venv
@@ -75,13 +82,15 @@ jobs:
             matrix:
                 python-version: ["3.12", "3.13", "3.14"]
         steps:
-            - uses: actions/checkout@v7
-            - uses: actions/setup-python@v6
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                persist-credentials: false
+            - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
               with:
                   python-version: ${{ matrix.python-version }}
                   cache: "pip"
             - name: Install Rust
-              uses: actions-rust-lang/setup-rust-toolchain@v1
+              uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1.17.0
             - name: build deeptools
               run: |
                   python -m venv venv

--- a/.github/workflows/test_rust.yml
+++ b/.github/workflows/test_rust.yml
@@ -6,12 +6,17 @@ on:
     schedule:
         - cron: "0 0 * * 0"
 
+permissions:
+    contents: read
+
 jobs:
     cargo_test:
         name: run cargo test
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                persist-credentials: false
             - run: rustup update stable && rustup default stable
             - name: cargo build
               run: cargo build --verbose

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,12 +20,14 @@ jobs:
                     - runner: ubuntu-22.04
                       target: aarch64
         steps:
-            - uses: actions/checkout@v7
-            - uses: actions/setup-python@v5
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                persist-credentials: false
+            - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
               with:
                   python-version: 3.x
             - name: Build wheels
-              uses: PyO3/maturin-action@v1
+              uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
               with:
                   target: ${{ matrix.platform.target }}
                   args: --release --out dist --find-interpreter
@@ -61,7 +63,7 @@ jobs:
                       # fi
                       # env | grep SSL  # for debugging when rust crate fails to find headers
             - name: Upload wheels
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                   name: wheels-linux-${{ matrix.platform.target }}
                   path: dist
@@ -76,12 +78,14 @@ jobs:
                     - runner: ubuntu-22.04
                       target: aarch64
         steps:
-            - uses: actions/checkout@v7
-            - uses: actions/setup-python@v5
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                persist-credentials: false
+            - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
               with:
                   python-version: 3.x
             - name: Build wheels
-              uses: PyO3/maturin-action@v1
+              uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
               with:
                   target: ${{ matrix.platform.target }}
                   args: --release --out dist --find-interpreter
@@ -94,7 +98,7 @@ jobs:
                         apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
                       fi
             - name: Upload wheels
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                   name: wheels-musllinux-${{ matrix.platform.target }}
                   path: dist
@@ -144,18 +148,20 @@ jobs:
                     - runner: macos-latest
                       target: aarch64
         steps:
-            - uses: actions/checkout@v7
-            - uses: actions/setup-python@v5
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                persist-credentials: false
+            - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
               with:
                   python-version: 3.x
             - name: Build wheels
-              uses: PyO3/maturin-action@v1
+              uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
               with:
                   target: ${{ matrix.platform.target }}
                   args: --release --out dist --find-interpreter
                   # sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
             - name: Upload wheels
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                   name: wheels-macos-${{ matrix.platform.target }}
                   path: dist
@@ -163,15 +169,17 @@ jobs:
     sdist:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v7
+            - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+              with:
+                persist-credentials: false
             - name: Build sdist
-              uses: PyO3/maturin-action@v1
+              uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
               with:
                   command: sdist
                   args: --out dist
                   # sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
             - name: Upload sdist
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                   name: wheels-sdist
                   path: dist
@@ -186,14 +194,14 @@ jobs:
             contents: write
             attestations: write
         steps:
-            - uses: actions/download-artifact@v4
+            - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
             - name: Generate artifact attestation
-              uses: actions/attest-build-provenance@v1
+              uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
               with:
                   subject-path: "wheels-*/*"
             - name: Publish to PyPI
               if: ${{ startsWith(github.ref, 'refs/tags/') }}
-              uses: PyO3/maturin-action@v1
+              uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
               env:
                   MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
               with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.11.0
+    hooks:
+      - id: zizmor


### PR DESCRIPTION
Adds [zizmor](https://docs.zizmor.sh/) as a pre-commit hook and applies its fixes to the GitHub Actions workflows.

## Changes
- **Add zizmor pre-commit hook** (`.pre-commit-config.yaml`), pinned to `v1.11.0`.
- **Pin all actions to commit SHAs** with version comments (`unpinned-uses`, 35 findings).
- **`persist-credentials: false`** on all `actions/checkout` steps so the token isn't left in `.git/config` (`artipacked`, 10 findings).
- **Minimal top-level `permissions: contents: read`** on `pypi.yml`, `test_planemo.yml`, `test_pytest.yml`, `test_rust.yml` (`excessive-permissions`, 9 findings). `wheels.yml` already had one.

## Result
zizmor went from 38 findings (19 medium, 10 high) to 0 errors/warnings. One informational finding remains: `use-trusted-publishing` in `pypi.yml`, which requires PyPI-side OIDC setup and was intentionally left out of this PR.