### PR TITLE
Rust backend: parallelism fixes for bigWig writer, alignmentSieve, computeMatrix

### DIFF
--- a/src/alignmentsieve.rs
+++ b/src/alignmentsieve.rs
@@ -4,6 +4,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyList;
 use rust_htslib::bam::record::CigarString;
 use rust_htslib::bam::{self, Header, Read, Reader, Writer};
+use rust_htslib::tpool::ThreadPool;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufWriter, Write};
@@ -108,7 +109,13 @@ pub fn r_alignmentsieve(
         None,
     );
 
-    // Open output writers
+    // Open output writers. When both the main and filtered-out BAM writers are active,
+    // give them a single shared htslib thread pool instead of calling `set_threads` on
+    // each independently: `set_threads` spins up its own private pool per call, so two
+    // independent calls with `writerthreads` each would request `2 * writerthreads` BGZF
+    // compression threads total, oversubscribing the `writerthreads` budget we intended.
+    let writer_pool = ThreadPool::new(writerthreads as u32).ok();
+
     let mut obam = if !bed {
         Some(
             Writer::from_path(ofile, &header, bam::Format::Bam)
@@ -118,7 +125,14 @@ pub fn r_alignmentsieve(
         None
     };
     if let Some(ref mut w) = obam {
-        let _ = w.set_threads(writerthreads);
+        match &writer_pool {
+            Some(pool) => {
+                let _ = w.set_thread_pool(pool);
+            }
+            None => {
+                let _ = w.set_threads(writerthreads);
+            }
+        }
     }
     let mut obed = if bed {
         Some(BufWriter::new(File::create(ofile).unwrap_or_else(|e| {
@@ -143,7 +157,14 @@ pub fn r_alignmentsieve(
         None
     };
     if let Some(ref mut w) = ofilterbam {
-        let _ = w.set_threads(writerthreads);
+        match &writer_pool {
+            Some(pool) => {
+                let _ = w.set_thread_pool(pool);
+            }
+            None => {
+                let _ = w.set_threads(writerthreads);
+            }
+        }
     }
     let mut ofilterbed = if write_filters && bed {
         Some(BufWriter::new(

--- a/src/bamcompare.rs
+++ b/src/bamcompare.rs
@@ -395,7 +395,7 @@ pub fn r_bamcompare(
     } else {
         Box::new(raw_lines)
     };
-    write_covfile(lines, ofile, ofiletype, chromsizes);
+    write_covfile(lines, ofile, ofiletype, chromsizes, nproc);
     Ok(())
 }
 

--- a/src/bamcoverage.rs
+++ b/src/bamcoverage.rs
@@ -289,6 +289,6 @@ pub fn r_bamcoverage(
         println!("Writing output to: {}", ofile);
     }
 
-    write_covfile(lines, ofile, ofiletype, chromsizes);
+    write_covfile(lines, ofile, ofiletype, chromsizes, nproc);
     Ok(())
 }

--- a/src/computematrix.rs
+++ b/src/computematrix.rs
@@ -273,28 +273,45 @@ pub fn r_computematrix(
 
     // Discriminate between reference-point and scale-regions mode.
 
-    let matrix: Vec<Vec<f32>> = pool.install(|| {
-        bw_files
+    // bwintervals is single-threaded per bigwig file (BigWigRead::get_interval takes
+    // &mut self, so one reader can't be shared across threads). Parallelizing only
+    // across bw_files.par_iter() therefore leaves most of a reserved node idle whenever
+    // there are fewer tracks than threads, which is the common case. Add a second
+    // parallelism axis by also chunking the region list per file, mirroring the
+    // "open one reader per worker, reuse across a chunk of regions" pattern bam_pileup
+    // already uses for BAM reading. Chunk count in one dimension is intentionally
+    // rounded up so busy still finishes at nproc-ish task count even with 1 bigwig file.
+    let chunks_per_file = (nproc / bw_files.len().max(1)).max(1);
+    let region_chunks = chunk_ranges(regions.len(), chunks_per_file);
+    let tasks: Vec<(usize, usize, usize)> = (0..bw_files.len())
+        .flat_map(|fi| region_chunks.iter().map(move |&(s, e)| (fi, s, e)))
+        .collect();
+
+    // rayon's par_iter().collect() on an indexed source (a Vec, here) is
+    // order-preserving: `results[k]` always corresponds to `tasks[k]`, regardless of
+    // which task finishes first. That lets the merge below stay a plain sequential
+    // walk instead of needing its own bookkeeping to figure out where each chunk goes.
+    let results: Vec<Vec<Vec<f32>>> = pool.install(|| {
+        tasks
             .par_iter()
-            .map(|i| {
+            .map(|&(fi, s, e)| {
                 bwintervals(
-                    &i,
-                    &regions,
-                    &slopregions,
+                    &bw_files[fi],
+                    &regions[s..e],
+                    &slopregions[s..e],
                     &scale_regions,
                     blacklist_index.as_deref(),
                 )
             })
-            .reduce(
-                || vec![vec![]; regions.len()],
-                |mut acc, vec_of_vecs| {
-                    for (i, inner_vec) in vec_of_vecs.into_iter().enumerate() {
-                        acc[i].extend(inner_vec);
-                    }
-                    acc
-                },
-            )
+            .collect()
     });
+
+    let mut matrix: Vec<Vec<f32>> = vec![Vec::new(); regions.len()];
+    for (&(_fi, s, e), chunk_result) in tasks.iter().zip(results.into_iter()) {
+        for (local_ix, region_ix) in (s..e).enumerate() {
+            matrix[region_ix].extend(chunk_result[local_ix].iter().copied());
+        }
+    }
     matrix_dump(
         sortregions,
         sortusing,
@@ -310,6 +327,27 @@ pub fn r_computematrix(
     );
 
     Ok(())
+}
+
+/// Split `[0, n)` into up to `k` contiguous, roughly-equal ranges. Returns a single
+/// `(0, n)` range if `n == 0` or `k <= 1`, so callers never need to special-case
+/// "no chunking" separately from "one chunk".
+fn chunk_ranges(n: usize, k: usize) -> Vec<(usize, usize)> {
+    if n == 0 || k <= 1 {
+        return vec![(0, n)];
+    }
+    let k = k.min(n);
+    let base = n / k;
+    let rem = n % k;
+    let mut ranges = Vec::with_capacity(k);
+    let mut start = 0;
+    for i in 0..k {
+        let len = base + if i < rem { 1 } else { 0 };
+        let end = start + len;
+        ranges.push((start, end));
+        start = end;
+    }
+    ranges
 }
 
 fn slop_region(

--- a/src/filehandler.rs
+++ b/src/filehandler.rs
@@ -31,7 +31,13 @@ pub fn bam_ispaired(bam_ifile: &str) -> bool {
     return false;
 }
 
-pub fn write_covfile<LI>(lines: LI, ofile: &str, filetype: &str, chromsizes: HashMap<String, u32>)
+pub fn write_covfile<LI>(
+    lines: LI,
+    ofile: &str,
+    filetype: &str,
+    chromsizes: HashMap<String, u32>,
+    nproc: usize,
+)
 where
     LI: Iterator<Item = (String, Value)>,
 {
@@ -51,12 +57,26 @@ where
         }
     } else {
         let vals = BedParserStreamingIterator::wrap_infallible_iter(lines, false);
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(1)
-            .build()
-            .expect("Unable to create tokio runtime for bw writing.");
-        let writer = BigWigWrite::create_file(ofile, chromsizes)
+        let mut writer = BigWigWrite::create_file(ofile, chromsizes)
             .unwrap_or_else(|e| panic!("Failed to create output bigwig file '{}': {}", ofile, e));
+        // bigtools spawns one async task per chromosome (zoom aggregation + section
+        // encoding) and funnels their output through a single sequential writer task
+        // that owns the actual file handle; the crate's own channels serialize that
+        // hand-off, so raising worker count only widens the per-chromosome encode
+        // stage, it does not add any concurrent writers to `ofile`.
+        // Mirrors bigtools' own bedgraphtobigwig CLI: skip the multi-thread runtime
+        // entirely at nproc == 1, since it would only ever have one consumer.
+        let runtime = if nproc <= 1 {
+            writer.options.channel_size = 0;
+            tokio::runtime::Builder::new_current_thread()
+                .build()
+                .expect("Unable to create tokio runtime for bw writing.")
+        } else {
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(nproc)
+                .build()
+                .expect("Unable to create tokio runtime for bw writing.")
+        };
         let _ = writer.write(vals, runtime);
     }
 }

--- a/src/filehandler.rs
+++ b/src/filehandler.rs
@@ -1,6 +1,8 @@
 use crate::calc::{max_float, mean_float, median_float, min_float, std_float, sum_float};
 use crate::covcalc::{Bin, Gtfparse, Region, Revalue, Scalingregions};
-use bigtools::beddata::BedParserStreamingIterator;
+use bigtools::bed::bedparser::parse_bedgraph;
+use bigtools::bed::indexer::index_chroms;
+use bigtools::beddata::{BedParserParallelStreamingIterator, BedParserStreamingIterator};
 use bigtools::{BigWigRead, BigWigWrite, Value};
 use flate2::Compression;
 use flate2::read::MultiGzDecoder;
@@ -11,7 +13,8 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::{BufReader, BufWriter, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use tempfile::Builder;
 
 pub fn bam_ispaired(bam_ifile: &str) -> bool {
     let mut bam = Reader::from_path(bam_ifile)
@@ -55,29 +58,98 @@ where
             )
             .unwrap_or_else(|e| panic!("Failed to write bedgraph line to '{}': {}", ofile, e));
         }
-    } else {
+    } else if nproc <= 1 {
+        // No point spooling to disk just to read it back sequentially: this is
+        // the base case bigtools' own bedgraphtobigwig CLI special-cases too
+        // (current_thread runtime, channel_size = 0, since there's only ever
+        // one consumer), and wrap_infallible_iter drives BigWigWrite directly
+        // off the in-memory iterator with zero disk round-trip.
         let vals = BedParserStreamingIterator::wrap_infallible_iter(lines, false);
         let mut writer = BigWigWrite::create_file(ofile, chromsizes)
             .unwrap_or_else(|e| panic!("Failed to create output bigwig file '{}': {}", ofile, e));
-        // bigtools spawns one async task per chromosome (zoom aggregation + section
-        // encoding) and funnels their output through a single sequential writer task
-        // that owns the actual file handle; the crate's own channels serialize that
-        // hand-off, so raising worker count only widens the per-chromosome encode
-        // stage, it does not add any concurrent writers to `ofile`.
-        // Mirrors bigtools' own bedgraphtobigwig CLI: skip the multi-thread runtime
-        // entirely at nproc == 1, since it would only ever have one consumer.
-        let runtime = if nproc <= 1 {
-            writer.options.channel_size = 0;
-            tokio::runtime::Builder::new_current_thread()
-                .build()
-                .expect("Unable to create tokio runtime for bw writing.")
-        } else {
-            tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(nproc)
-                .build()
-                .expect("Unable to create tokio runtime for bw writing.")
-        };
+        writer.options.channel_size = 0;
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("Unable to create tokio runtime for bw writing.");
         let _ = writer.write(vals, runtime);
+    } else {
+        // nproc > 1: only worth spooling to a merged temp file at all if there's
+        // a chance of using bigtools' indexed parallel reader
+        // (BedParserParallelStreamingIterator), the same path bigtools' own
+        // bedgraphtobigwig CLI uses, which reads and encodes multiple
+        // chromosomes concurrently straight off disk instead of the single
+        // sequential stream wrap_infallible_iter/BedParserStreamingIterator
+        // produce. index_chroms() needs a real sorted file on disk to build its
+        // byte-offset index, so this path unavoidably costs one extra write
+        // pass over the in-memory path used at nproc <= 1.
+        let merged = Builder::new()
+            .prefix("deeptoolstmp_merged_")
+            .suffix(".bedgraph")
+            .tempfile()
+            .expect("Failed to create merged temp bedgraph file.");
+        {
+            let mut mergedwriter = BufWriter::new(merged.reopen().unwrap());
+            for (chrom, val) in lines {
+                writeln!(
+                    mergedwriter,
+                    "{}\t{}\t{}\t{}",
+                    chrom, val.start, val.end, val.value
+                )
+                .unwrap();
+            }
+        }
+        let mergedpath = merged.into_temp_path();
+
+        let writer = BigWigWrite::create_file(ofile, chromsizes).unwrap();
+        // bigtools spawns one async task per chromosome (zoom aggregation and
+        // section encoding) and funnels their output through a single
+        // sequential writer task that owns the actual file handle; the
+        // crate's own channels serialize that hand-off, so raising worker
+        // count only widens the per-chromosome encode stage, it does not add
+        // any concurrent writers to `ofile`.
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(nproc)
+            .build()
+            .expect("Unable to create tokio runtime for bw writing.");
+
+        // Raven 24-thread benchmarks (see PR discussion) showed the parallel
+        // indexed-read path below is a real win on chip/rna-scale outputs (up
+        // to ~3.8x faster) but a regression on whole-genome-scale ones
+        // (bamCoverage/bamCompare on WGS samples dropped to 0.78-0.85x), even
+        // though memory stayed flat in both cases. index_chroms() does one
+        // full linear scan of the merged bedgraph to build its byte-offset
+        // index before BedParserParallelStreamingIterator does its own
+        // per-chromosome reads; on small/medium files that extra pass is
+        // cheap relative to the parse-time it saves, but on multi-hundred-MB
+        // WGS bedgraphs the extra full-file read starts to dominate. This
+        // mirrors the size-based gate bigtools' own bedgraphtobigwig CLI uses
+        // (auto-enables parallel above ~200MB), just inverted: our data says
+        // to prefer the parallel path *below* a size threshold, not above it.
+        const PARALLEL_READ_SIZE_THRESHOLD_BYTES: u64 = 200_000_000;
+        let merged_size = std::fs::metadata(&mergedpath).map(|m| m.len()).unwrap_or(0);
+        let chrom_indices = if merged_size < PARALLEL_READ_SIZE_THRESHOLD_BYTES {
+            let infile = File::open(&mergedpath).expect("Failed to reopen merged bedgraph.");
+            index_chroms(infile).expect("Failed to index merged bedgraph.")
+        } else {
+            None
+        };
+
+        match chrom_indices {
+            Some(chrom_indices) => {
+                let data = BedParserParallelStreamingIterator::new(
+                    chrom_indices,
+                    false,
+                    PathBuf::from(&mergedpath),
+                    parse_bedgraph,
+                );
+                let _ = writer.write(data, runtime);
+            }
+            None => {
+                let infile = File::open(&mergedpath).expect("Failed to reopen merged bedgraph.");
+                let vals = BedParserStreamingIterator::from_bedgraph_file(infile, false);
+                let _ = writer.write(vals, runtime);
+            }
+        }
     }
 }
 
@@ -677,8 +749,8 @@ pub fn chrombounds_from_bam(bamfiles: Vec<&str>) -> HashMap<String, u32> {
 
 pub fn bwintervals(
     bwfile: &str,
-    regions: &Vec<Region>,
-    slopregions: &Vec<Vec<Bin>>,
+    regions: &[Region],
+    slopregions: &[Vec<Bin>],
     scale_regions: &Scalingregions,
     blacklist_index: Option<&crate::filtering::BlacklistIndex>,
 ) -> Vec<Vec<f32>> {

--- a/src/filehandler.rs
+++ b/src/filehandler.rs
@@ -1,8 +1,6 @@
 use crate::calc::{max_float, mean_float, median_float, min_float, std_float, sum_float};
 use crate::covcalc::{Bin, Gtfparse, Region, Revalue, Scalingregions};
-use bigtools::bed::bedparser::parse_bedgraph;
-use bigtools::bed::indexer::index_chroms;
-use bigtools::beddata::{BedParserParallelStreamingIterator, BedParserStreamingIterator};
+use bigtools::beddata::BedParserStreamingIterator;
 use bigtools::{BigWigRead, BigWigWrite, Value};
 use flate2::Compression;
 use flate2::read::MultiGzDecoder;
@@ -13,8 +11,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::{BufReader, BufWriter, Write};
-use std::path::{Path, PathBuf};
-use tempfile::Builder;
+use std::path::Path;
 
 pub fn bam_ispaired(bam_ifile: &str) -> bool {
     let mut bam = Reader::from_path(bam_ifile)
@@ -58,98 +55,29 @@ where
             )
             .unwrap_or_else(|e| panic!("Failed to write bedgraph line to '{}': {}", ofile, e));
         }
-    } else if nproc <= 1 {
-        // No point spooling to disk just to read it back sequentially: this is
-        // the base case bigtools' own bedgraphtobigwig CLI special-cases too
-        // (current_thread runtime, channel_size = 0, since there's only ever
-        // one consumer), and wrap_infallible_iter drives BigWigWrite directly
-        // off the in-memory iterator with zero disk round-trip.
+    } else {
         let vals = BedParserStreamingIterator::wrap_infallible_iter(lines, false);
         let mut writer = BigWigWrite::create_file(ofile, chromsizes)
             .unwrap_or_else(|e| panic!("Failed to create output bigwig file '{}': {}", ofile, e));
-        writer.options.channel_size = 0;
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .build()
-            .expect("Unable to create tokio runtime for bw writing.");
-        let _ = writer.write(vals, runtime);
-    } else {
-        // nproc > 1: only worth spooling to a merged temp file at all if there's
-        // a chance of using bigtools' indexed parallel reader
-        // (BedParserParallelStreamingIterator), the same path bigtools' own
-        // bedgraphtobigwig CLI uses, which reads and encodes multiple
-        // chromosomes concurrently straight off disk instead of the single
-        // sequential stream wrap_infallible_iter/BedParserStreamingIterator
-        // produce. index_chroms() needs a real sorted file on disk to build its
-        // byte-offset index, so this path unavoidably costs one extra write
-        // pass over the in-memory path used at nproc <= 1.
-        let merged = Builder::new()
-            .prefix("deeptoolstmp_merged_")
-            .suffix(".bedgraph")
-            .tempfile()
-            .expect("Failed to create merged temp bedgraph file.");
-        {
-            let mut mergedwriter = BufWriter::new(merged.reopen().unwrap());
-            for (chrom, val) in lines {
-                writeln!(
-                    mergedwriter,
-                    "{}\t{}\t{}\t{}",
-                    chrom, val.start, val.end, val.value
-                )
-                .unwrap();
-            }
-        }
-        let mergedpath = merged.into_temp_path();
-
-        let writer = BigWigWrite::create_file(ofile, chromsizes).unwrap();
-        // bigtools spawns one async task per chromosome (zoom aggregation and
-        // section encoding) and funnels their output through a single
-        // sequential writer task that owns the actual file handle; the
-        // crate's own channels serialize that hand-off, so raising worker
-        // count only widens the per-chromosome encode stage, it does not add
-        // any concurrent writers to `ofile`.
-        let runtime = tokio::runtime::Builder::new_multi_thread()
-            .worker_threads(nproc)
-            .build()
-            .expect("Unable to create tokio runtime for bw writing.");
-
-        // Raven 24-thread benchmarks (see PR discussion) showed the parallel
-        // indexed-read path below is a real win on chip/rna-scale outputs (up
-        // to ~3.8x faster) but a regression on whole-genome-scale ones
-        // (bamCoverage/bamCompare on WGS samples dropped to 0.78-0.85x), even
-        // though memory stayed flat in both cases. index_chroms() does one
-        // full linear scan of the merged bedgraph to build its byte-offset
-        // index before BedParserParallelStreamingIterator does its own
-        // per-chromosome reads; on small/medium files that extra pass is
-        // cheap relative to the parse-time it saves, but on multi-hundred-MB
-        // WGS bedgraphs the extra full-file read starts to dominate. This
-        // mirrors the size-based gate bigtools' own bedgraphtobigwig CLI uses
-        // (auto-enables parallel above ~200MB), just inverted: our data says
-        // to prefer the parallel path *below* a size threshold, not above it.
-        const PARALLEL_READ_SIZE_THRESHOLD_BYTES: u64 = 200_000_000;
-        let merged_size = std::fs::metadata(&mergedpath).map(|m| m.len()).unwrap_or(0);
-        let chrom_indices = if merged_size < PARALLEL_READ_SIZE_THRESHOLD_BYTES {
-            let infile = File::open(&mergedpath).expect("Failed to reopen merged bedgraph.");
-            index_chroms(infile).expect("Failed to index merged bedgraph.")
+        // bigtools spawns one async task per chromosome (zoom aggregation + section
+        // encoding) and funnels their output through a single sequential writer task
+        // that owns the actual file handle; the crate's own channels serialize that
+        // hand-off, so raising worker count only widens the per-chromosome encode
+        // stage, it does not add any concurrent writers to `ofile`.
+        // Mirrors bigtools' own bedgraphtobigwig CLI: skip the multi-thread runtime
+        // entirely at nproc == 1, since it would only ever have one consumer.
+        let runtime = if nproc <= 1 {
+            writer.options.channel_size = 0;
+            tokio::runtime::Builder::new_current_thread()
+                .build()
+                .expect("Unable to create tokio runtime for bw writing.")
         } else {
-            None
+            tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(nproc)
+                .build()
+                .expect("Unable to create tokio runtime for bw writing.")
         };
-
-        match chrom_indices {
-            Some(chrom_indices) => {
-                let data = BedParserParallelStreamingIterator::new(
-                    chrom_indices,
-                    false,
-                    PathBuf::from(&mergedpath),
-                    parse_bedgraph,
-                );
-                let _ = writer.write(data, runtime);
-            }
-            None => {
-                let infile = File::open(&mergedpath).expect("Failed to reopen merged bedgraph.");
-                let vals = BedParserStreamingIterator::from_bedgraph_file(infile, false);
-                let _ = writer.write(vals, runtime);
-            }
-        }
+        let _ = writer.write(vals, runtime);
     }
 }
 


### PR DESCRIPTION

**Welcome to deepTools GitHub repository! Please check the following regarding
your pull request :**

 - [ ] Does the PR contain new feature?
 - [x] Does the PR contain bugfix?
 - [ ] Does the PR contain documentation changes?
 - [ ] Does the PR contain changes to the galaxy wrapper?

## Summary

Three bounded parallelism fixes in the Rust backend, found while checking why bamCoverage/bamCompare's bigWig writer, alignmentSieve, and computeMatrix don't scale as well as expected with `-p`. Each commit is independently buildable and testable. Rebased onto current `4.0.0` (`0f07abf3`, which independently fixed computeMatrix's hashmap-based memory footprint) to keep the comparison fair.

1. `4f483b94` bigwig writer: use `nproc` for the tokio runtime, skip the multi-thread runtime entirely at `-p 1` (mirrors bigtools' own `bedgraphtobigwig` CLI behavior).
2. `03a525b5` alignmentSieve: share one htslib thread pool between the main and `--filteredOutReads` BAM writers, instead of two independent `set_threads()` calls that were oversubscribing cores (up to `2 * (nproc - 2)` threads competing for `nproc` reserved cores).
3. `ee7d9e8c` computeMatrix: add a region-chunk axis to matrix-building parallelism, so core usage isn't bounded by `min(nproc, bw_files.len())` on single- or few-sample runs.

A fourth commit (`07aca1fa`, reading the bigwig writer's input from a merged, indexed bedgraph instead of a sequential one) is also in the branch history but reverted (`5291287b`): benchmarking showed it wrote a temp file to disk at `-p` > 1 that the pre-change baseline never touched, which made it strictly worse than baseline above roughly 200MB of output, i.e. most chip/wgs samples. Kept the `bwintervals` slice-signature widening it introduced, since commit 3 needs it.

Root causes for items 1-3 were confirmed against the actual pinned library source, not just documentation: `rust-htslib` v1.0.1 (cloned at that tag) for item 2, and `bigtools` 0.5.8 (cloned at HEAD, one commit past our pinned tag) for item 1.

## Testing

- Full pytest suite passes after every commit (231/232 locally, same one pre-existing unrelated failure as `4.0.0`).
- Manual smoke tests: byte-identical or diff-identical output across `-p 1/4/12` for the affected tools.
- Benchmarked on raven (24-thread SLURM profile, 10 reps per sample, human + triticum references). Summary, full numbers and mechanism writeups are in the PR comments below:
  - bamCoverage/bamCompare/alignmentSieve/multibamSummary: at parity with baseline (~1.0x, ~1.0x mem) everywhere except bamCoverage on low-depth/large-genome samples (triticum chip/rna), where the bigwig writer's per-chromosome parallel encode gives a real 1.5-3.6x speedup, no memory cost. WGS samples see no gain in either species since read-depth-bound coverage computation dominates wall time there, not the write stage.
  - computeMatrix: flat parity (1.0x) when the input already has enough bigwig files to saturate `-p 24` on the file axis alone (15 files here). With few files (3 here), the region-chunking commit still gives a real ~1.7x speedup, down from an earlier (invalid, stale-baseline) reading of up to 2.23x now that both sides share `4.0.0`'s hashmap-to-vector fix. That speedup comes with a real memory cost on the largest genome (triticum, 1.19x baseline RSS), not the near-free win it first looked like.

cc colleagues for input before this merges.
