### PR TITLE
computeMatrix: decode gzipped BED lines in sortMatrix (fixes #1423)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+unreleased
+* computeMatrix (and computeMatrixOperations sort) no longer crash with `TypeError: startswith first arg must be bytes` when the regions file is gzipped; loadBED now decodes the lines it reads, as loadGTF already did. #1423
+
 3.5.5
 * drop support for python 3.7
 * doc fixes (argparse properly displayed, minor changes in installation instructions)

--- a/deeptools/computeMatrixOperations.py
+++ b/deeptools/computeMatrixOperations.py
@@ -595,6 +595,8 @@ def loadBED(line, fp, fname, labelColumn, labels, regions, defaultGroup):
     localRegions[name] = len(localRegions)
 
     for line in fp:
+        if not isinstance(line, str):
+            line = line.decode('ascii')
         if line.startswith("#") and labelColumn is None:
             if len(localRegions) > 0:
                 label = line[1:].strip()

--- a/deeptools/test/test_computeMatrixOperations.py
+++ b/deeptools/test/test_computeMatrixOperations.py
@@ -163,3 +163,23 @@ class TestComputeMatrixOperations(object):
         expectedh = '10ea07d1aa58f44625abe2142ef76094'
         assert f'{h}' == f'{expectedh}'
         os.remove(oname)
+
+    def testsortGzippedBED(self):
+        """
+        computeMatrixOperations sort with a gzipped BED (issue #1423)
+        """
+        bedgz = "/tmp/computeMatrixOperations.bed.gz"
+        with open(self.bed, "rb") as fin, gzip.open(bedgz, "wb") as fout:
+            fout.write(fin.read())
+        oname = "/tmp/sorted_gz.mat.gz"
+        args = "sort -m {} -o {} -R {}".format(self.matrix, oname, bedgz)
+        args = args.split()
+        cmo.main(args)
+        f = gzip.GzipFile(oname)
+        getHeader(f)  # Skip the header, which can be in a different order
+        h = hashlib.md5(f.read()).hexdigest()
+        f.close()
+        expectedh = '10ea07d1aa58f44625abe2142ef76094'
+        assert f'{h}' == f'{expectedh}'
+        os.remove(oname)
+        os.remove(bedgz)

--- a/deeptools/test/test_heatmapper.py
+++ b/deeptools/test/test_heatmapper.py
@@ -1,3 +1,4 @@
+import gzip
 import os
 import sys
 
@@ -101,6 +102,22 @@ def test_computeMatrix_multiple_bed():
     os.system('gunzip -f /tmp/_test.mat.gz')
     assert cmpMatrices(ROOT + '/master_multibed.mat', '/tmp/_test.mat') is True
     os.remove('/tmp/_test.mat')
+
+
+def test_computeMatrix_gzipped_bed():
+    """
+    A gzipped BED must give the same matrix as the plain one (issue #1423):
+    the default --sortRegions keep re-reads the regions file in sortMatrix.
+    """
+    with open(ROOT + '/test2.bed', 'rb') as fin, gzip.open('/tmp/_test2.bed.gz', 'wb') as fout:
+        fout.write(fin.read())
+    args = "reference-point -R /tmp/_test2.bed.gz -S {0}/test.bw  -b 100 -a 100 " \
+           "--outFileName /tmp/_test.mat.gz  -bs 1 -p 1".format(ROOT).split()
+    deeptools.computeMatrix.main(args)
+    os.system('gunzip -f /tmp/_test.mat.gz')
+    assert cmpMatrices(ROOT + '/master.mat', '/tmp/_test.mat') is True
+    os.remove('/tmp/_test.mat')
+    os.remove('/tmp/_test2.bed.gz')
 
 
 def test_computeMatrix_region_extend_over_chr_end():


### PR DESCRIPTION
**Welcome to deepTools GitHub repository! Please check the following regarding
your pull request :**

 - [ ] Does the PR contain new feature?
 - [x] Does the PR contain bugfix?
 - [ ] Does the PR contain documentation changes?
 - [ ] Does the PR contain changes to the galaxy wrapper?

Fixes #1423.

This is the `deeptoolsintervals/parse.py#L15` pattern you pointed at in the issue thread: the same `if not isinstance(line, str): line = line.decode('ascii')` guard that `getNext()` uses there and that `loadGTF()` already has a few lines further down in this file, applied to `loadBED()`. Opening it because the issue is still open since March and unassigned, but obviously please close this if this is not needed.

**Cause.** With the default `--sortRegions keep`, `computeMatrix` re-reads the regions file in `computeMatrixOperations.sortMatrix()` to restore the input order. `deeptoolsintervals.openPossiblyCompressed()` opens a gzipped file in binary mode; `getNext()` decodes the header/first line, but `loadBED()` then iterates the remaining lines of the handle as `bytes`, so `line.startswith("#")` raises `TypeError: startswith first arg must be bytes or a tuple of bytes, not str`. The matrix itself is computed fine (the deeptoolsintervals parser handles compressed files); the crash happens right before the matrix is written, so every `computeMatrix` run on a `.bed.gz` fails unless `--sortRegions no/ascend/descend` is given. `computeMatrixOperations sort -R regions.bed.gz` fails the same way. `loadGTF()` in the same file already decodes its lines.

**Fix.** Decode non-`str` lines in `loadBED()` exactly as `loadGTF()` does (two lines in `deeptools/computeMatrixOperations.py`). No change for plain-text BED files.

**Tests.** `test_heatmapper.py::test_computeMatrix_gzipped_bed` runs `computeMatrix reference-point` on a gzipped copy of the existing `test2.bed` and checks the matrix equals `master.mat`; `test_computeMatrixOperations.py::testsortGzippedBED` runs `computeMatrixOperations sort` on a gzipped copy of `computeMatrixOperations.bed` and checks the same md5 as the existing `testsort`. Both fail on `master` with the `TypeError` above and pass with the fix.

**Run.** `pytest deeptools/test/test_heatmapper.py deeptools/test/test_computeMatrixOperations.py`: 21 passed + 2 failed (the new tests) before, 23 passed after; full suite 100 passed with the fix (the two remaining failures, `test_plotCoverage_default` and `test_tools`, fail identically on unmodified `master` in this environment). `flake8` with the CI options is clean on the changed files. A `CHANGES.txt` bullet is included under an `unreleased` heading.

Found while working through open issues in Mytochondria, a volunteer project that verifies fixes for the software behind published results (methods and harnesses: https://github.com/cindykrafft/mytochondria/tree/main/audits/deeptools)

---
_Generated by [Claude Code](https://claude.ai/code)_